### PR TITLE
fix: fix log ClientConfig error caused by __repr__ method

### DIFF
--- a/infinistore/lib.py
+++ b/infinistore/lib.py
@@ -67,7 +67,7 @@ class ClientConfig(_infinistore.ClientConfig):
         return (
             f"ServerConfig(service_port={self.service_port}, "
             f"log_level='{self.log_level}', host_addr='{self.host_addr}', "
-            f"connection_type='{self.connection_type.name}')"
+            f"connection_type='{self.connection_type}')"
             f"dev_name='{self.dev_name}', ib_port={self.ib_port}, link_type='{self.link_type}'"
         )
 


### PR DESCRIPTION
`connection_type` is a str, so it is no `name` attribute, it will throw error if i attempt to log `ClientConfig`