### PR TITLE
fix: coredump without rdam

### DIFF
--- a/src/rdma.cpp
+++ b/src/rdma.cpp
@@ -47,7 +47,7 @@ int open_rdma_device(std::string dev_name, int ib_port, std::string link_type, i
     struct ibv_device *ib_dev;
     int num_devices;
     dev_list = ibv_get_device_list(&num_devices);
-    if (!dev_list) {
+    if (!dev_list || num_devices <= 0) {
         ERROR("Failed to get RDMA devices list");
         return -1;
     }


### PR DESCRIPTION
ibv_get_device_list will always return a list end with null.
Therefore this will cause crash in this line.  https://github.com/bytedance/InfiniStore/blob/main/src/rdma.cpp#L69